### PR TITLE
Remove link to same page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This guide covers building a Let's Split v2. Order your parts and read over this
 
 # Contents
 
-* [Introduction](README.md)
+* Introduction _\(this page\)_
 * [Assembly](assembly.md)
 * [Flashing](flashing.md)
 * [RGB Underglow](rgb-underglow.md)


### PR DESCRIPTION
This change removes the link to README.md within README.md.

Personally, when reading the Table of Contents section, I tend to click the Introduction link, thinking it's a new page. When that leads back to the same page, I get a bit confused, until I check the link and see that it points to the page I'm on. This change helps to clarify that the current page is included in the TOC.