### PR TITLE
Update flashing command to reflect changes in QMK base

### DIFF
--- a/flashing.md
+++ b/flashing.md
@@ -30,10 +30,10 @@ See [/u/CampAsAChamp's Windows Guide](https://github.com/CampAsAChamp/LetsSplitW
 
 ### Build Keymap (QMK)
 
-From the lets_split directory:
+From the qmk_firmware directory:
 
 ```
-make rev2-YOUR_KEYMAP_NAME-avrdude
+make lets_split-rev2-YOUR_KEYMAP_NAME-avrdude
 ```
 
 Don't forget to replace `YOUR_KEYMAP_NAME` with the actual name of your keymap.
@@ -50,10 +50,10 @@ You will have 8 seconds to flash before it continues on to the sketch.
 
 ### Flash
 
-QMK now includes a very easy way to automatically find the serial port and flash without having to race the bootloader. From the keymap directory type (`$` indicates the prompt. Don't type that):
+QMK now includes a very easy way to automatically find the serial port and flash without having to race the bootloader. From the qmk directory type (`$` indicates the prompt. Don't type that):
 
 ```
-$ make rev2-YOUR_KEYMAP_NAME-avrdude
+$ make lets_split-rev2-YOUR_KEYMAP_NAME-avrdude
 ```
 
 Be sure to replace `YOUR_KEYMAP_NAME` with the name of your keymap.
@@ -61,7 +61,7 @@ Be sure to replace `YOUR_KEYMAP_NAME` with the name of your keymap.
 Example:
 
 ```bash
-$ make rev2-YOUR_KEYMAP_NAME-avrdude
+$ make lets_split-rev2-YOUR_KEYMAP_NAME-avrdude
 Reset your Pro Micro now
 
 Connecting to programmer: .


### PR DESCRIPTION
If you rebase your QMK fork to the origin then try to flash your LS you will likely encounter the following error if running the command in this way from the keyboard folder:
https://github.com/qmk/qmk_firmware/issues/1690

They are adjusting QMK so that it must be run from the root folder with the command `make lets_split-rev2-default-avrdude`
https://github.com/qmk/qmk_firmware/issues/1659

This way should still work for people with outdated forks, while supporting the latest.

Another person that was looking at this guide:
https://www.reddit.com/r/olkb/comments/6z6883/im_struggling_to_make_a_qmk_build_environment/