### PR TITLE
Update assembly.md

### DIFF
--- a/assembly.md
+++ b/assembly.md
@@ -163,7 +163,9 @@ The long part of the pins should be protruding from the bottom. We'll trim these
 
 ## Mount the Pro Micro
 
-**Pay special attention on this step**. There are several things that need to be done in the right order and orientation.
+**🚨Pay special attention on this step🚨**. 
+
+**There are several things that need to be done in the right order and orientation. Specifically, "TOP" AND "BOTTOM" are the OPPOSITE of what you might think**
 
 > *Tip:* Flash your Pro Micro now before you mount it. You can test it by using a multimeter to measure the voltage between VCC and RAW. It should be around 5V. If it's bad it'll be a lot less headache than desoldering.
 


### PR DESCRIPTION
your pictures are totally right. it's the printed words on the board that appear to be completely opposite. I guess "top up" refers to when you've finished soldering and you flip the board over, and THEN top is up? But it's not up when you're soldering. whatever. i don't get it but maybe most other people do. 