### PR TITLE
Update PCB URLs

### DIFF
--- a/getting-pcbs.md
+++ b/getting-pcbs.md
@@ -15,11 +15,10 @@
 ## Buying today
 
 **If you're getting the V2 boards:**
-- [beekeeb.com](https://beekeeb.com/lets-split-v2-pcbs/)
+- [beekeeb.com](https://shop.beekeeb.com/product/lets-split-v2-pcbs/)
 - [mehkee.com](https://mehkee.com/products/lets-split-pcb?variant=44914069775)
-- [smashingacrylics.co.uk](https://smashingacrylics.co.uk/product/lets-split-pcb-kits/) (kit)
-- [spacecat.design](https://spacecat.design/products/lets-split-pcbs)
 - [switchtop.com](http://www.switchtop.com/product/let-s-split-40-percent-pcb)
+- [mechboards.co.uk](https://mechboards.co.uk/products/lets-split-kit) (kit)
 - Join a group buy ([obligatory PSA](https://www.reddit.com/r/MechanicalKeyboards/wiki/psagroupbuys)) like /u/DeductiveMonkee's [group buy](https://www.reddit.com/r/mechmarket/comments/5ti0g4/gb_lets_split_kits/) (blue PCBs)
 - Buy one on [mechmarket](https://www.reddit.com/r/mechmarket/)
 - Print your own using the Gerber files from /u/wootpatoot's [let-s-split-v2 github](https://github.com/climbalima/let-s-Split-v2) repo.


### PR DESCRIPTION
- Update URL for beekeeb.com, link directly to shop.
- Removed smashing acrylics.co.uk site is a holding domain now.
- Removed spacecat.design, just links to an empty eBay account
- Added mechboards.co.uk kit link.