### PR TITLE
Add troubleshooting: One side isn't working: Advise activating the SPLIT_USB_DETECT feature in the firmware.

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -29,6 +29,8 @@ If you're having trouble with a dead column right over your Pro Micro it could b
 - Make sure J1 on the Pro Micro is **not** bridged.
 - Make sure you're using a TRRS cable, not a TRS cable.
 - Make sure your Pro Micros are in the correct orientation.
+- You may have an older version of the Pro Micro. You may need to add the line `#define SPLIT_USB_DETECT` to your firmware in `/keyboards/lets_split/keymaps/default/config.h`. (See: [Split Keyboard Configuration Options](https://docs.qmk.fm/#/feature_split_keyboard?id=hardware-configuration-options)).
+
 
 ### Multiple characters are output when pressing a single key
 


### PR DESCRIPTION
A vendor named Beekeep is selling these Let's Split kits with a "legacy Pro Micro". 

These can be made to work, but require a 1-line modification to the firmware. The vendor is clear about this when selling the product, but it would be good to have this information Google-able in case they do like I did, bought a kit half a year ago, received the instructions and didn't understand what he meant by it, and  built the keyboard, and couldn't find any help on why half the keyboard was dead when both sides work individually.

The vendor's URL is here https://www.etsy.com/listing/1080042613/lets-split-v2-keyboard-pcb-kit